### PR TITLE
Add descriptions for CONP terms

### DIFF
--- a/terms/CONP_DATS_Terms/isAbout/AdultHuman.jsonld
+++ b/terms/CONP_DATS_Terms/isAbout/AdultHuman.jsonld
@@ -9,5 +9,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0100363",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A person having attained full growth or maturity, defined as 21 years of age or older. (Based on definition of adult from the National Institutes of Health CRISP database)"
 }

--- a/terms/CONP_DATS_Terms/isAbout/AdultHuman.jsonld
+++ b/terms/CONP_DATS_Terms/isAbout/AdultHuman.jsonld
@@ -10,5 +10,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "A person having attained full growth or maturity, defined as 21 years of age or older. (Based on definition of adult from the National Institutes of Health CRISP database)"
+    "description": "A person having attained full growth or maturity, defined as 21 years of age or older. (Based on definition of adult from the National Institutes of Health CRISP database)",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/isAbout/AlzheimersDisease.jsonld
+++ b/terms/CONP_DATS_Terms/isAbout/AlzheimersDisease.jsonld
@@ -9,5 +9,7 @@
     "sameAs": "http://purl.bioontology.org/ontology/SNOMEDCT/26929004",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A progressive, neurodegenerative disease characterized by loss of function and death of nerve cells in several areas of the brain leading to loss of cognitive function such as memory and language.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
 }

--- a/terms/CONP_DATS_Terms/isAbout/AlzheimersDisease.jsonld
+++ b/terms/CONP_DATS_Terms/isAbout/AlzheimersDisease.jsonld
@@ -11,5 +11,5 @@
         "valueType": "xsd:string"
     },
     "description": "A progressive, neurodegenerative disease characterized by loss of function and death of nerve cells in several areas of the brain leading to loss of cognitive function such as memory and language.",
-    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/isAbout/TotalRNA.jsonld
+++ b/terms/CONP_DATS_Terms/isAbout/TotalRNA.jsonld
@@ -9,5 +9,7 @@
     "sameAs": "http://www.ebi.ac.uk/efo/EFO_0004964",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A RNA extract that is the output of an extraction process in which total RNA from either whole cells or from specific cellular compartment(s)/organelle(s) are isolated from a specimenA RNA extract that is the output of an extraction process in which total celluar and organelle RNA molecules are isolated from a specimen.",
+    "citation": "Description reference: Experimental Factor Ontology (EFO), version 3.33.0, 2021-08-20. Licensed under http://www.apache.org/licenses/LICENSE-2.0."
 }

--- a/terms/CONP_DATS_Terms/keywords/7T.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/7T.jsonld
@@ -13,5 +13,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "7 Tesla Magnetic Resonance Imaging"
-    }
+    },
+    "description": "MRI that uses a magnet capable of producing a 7 telsa field strength. This increased magnet strength is can produce images with greater signal-to-noise ratio and increased spatial resolution, or faster imaging at standard resolution.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/ASD.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/ASD.jsonld
@@ -13,5 +13,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "autism spectrum disorder"
-    }
+    },
+    "description": "A spectrum of developmental disorders that includes autism, Asperger syndrome, and Rett syndrome. Signs and symptoms include poor communication skills, defective social interactions, and repetitive behaviors.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Attention.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Attention.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0100980",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The cognitive process of selectively concentrating on one aspect of the environment while ignoring other things.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Brain.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Brain.jsonld
@@ -13,5 +13,7 @@
     "ontologyConceptID": "UBERON:0000955",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The part of the central nervous system contained within the cranium, comprising the forebrain, midbrain, hindbrain, and metencephalon. It is derived from the anterior part of the embryonic neural tube (or the encephalon). Does not include retina. (CUMBO)The rostral topographic division of the cerebrospinal axis, while the caudal division is the spinal cord. The usual criterion for distinguishing the two divisions in the adult is that the vertebrate brain lies within the skull whereas the spinal cord lies within the spinal (vertebral) column, although this is a difficult problem. (Swanson, 2014)",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/BrainImaging.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/BrainImaging.jsonld
@@ -10,7 +10,11 @@
         "DATS"
     ],
     "closeMatch": "http://uri.interlex.org/base/ilx_0497864",
+    "ontologyConceptID": "NCIT:C173635",
     "responseOptions": {
-        "valueType": "xsd:string"
-    }
+        "valueType": "xsd:string",
+        "allowableValues": "Neuroimaging"
+    },
+    "description": "The use of various techniques to directly or indirectly image the anatomy and function of the central nervous system.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/CognitiveFlexibility.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/CognitiveFlexibility.jsonld
@@ -12,5 +12,7 @@
     "ontologyConceptID": "NCIT:C99493",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The ability to restructure knowledge and change behavioral responses depending on the context of a situation.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Control.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Control.jsonld
@@ -9,8 +9,10 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "SNOMEDCT:246106000",
+    "ontologyConceptID": "NCIT:C61299",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The act of directing or determining; regulation or maintenance of a function or action; a relation of constraint of one entity (thing or person or group) by another.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Diffusion.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Diffusion.jsonld
@@ -9,8 +9,10 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "SNOMEDCT:46638006",
+    "ontologyConceptID": "NCIT:C82333",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The movement of chemical species under the influence of a concentration difference and as a result of random thermal agitation. The species will move from the high concentration area to the low concentration area till the concentration is uniform in the whole phase.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/DiffusionTensorImaging.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/DiffusionTensorImaging.jsonld
@@ -13,5 +13,7 @@
     "ontologyConceptID": "NCIT:C64862",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A type of diffusion-weighted magnetic resonance imaging (DW-MRI) that maps the diffusion of water in three dimensions, the principal purpose of which is to image the white matter of the brain, specifically measuring the anisotropy, location, and orientation of the neural tracts, which can demonstrate microstructural changes or differences with neuropathology and treatment.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/EEG.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/EEG.jsonld
@@ -10,8 +10,11 @@
         "DATS"
     ],
     "closeMatch": "http://purl.bioontology.org/ontology/SNOMEDCT/54550000",
+    "ontologyConceptID": "NCIT:C38054",
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "electroencephalogram"
-    }
+    },
+    "description": "The neurophysiologic exploration of the electrical activity of the brain by the application of electrodes to the scalp. The resulting traces are known as an electroencephalogram (EEG). This test is used to assess brain damage, epilepsy and other problems.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/FunctionalMRI.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/FunctionalMRI.jsonld
@@ -14,5 +14,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "fMRI"
-    }
+    },
+    "description": "The principle of functional MRI imaging is to take a series of images of an organ in quick succession and to statistically analyze the images for differences among them. Most commonly used in studies of brain function.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/GeneExpression.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/GeneExpression.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0104581",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The analysis of levels and patterns of synthesis of gene products (proteins and functional RNA) including interpretation in functional terms of gene expression data.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Hippocampus.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Hippocampus.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0105021",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A part of the hippocampal formation consisting of a three layered cortex located in the forebrain bordered by the medial surface of the lateral ventricle, the dentate gyrus and the subiculum. It has 3 subfields termed CA1, CA2 and CA3. The term hippocampus is often used synonymously with hippocampal formation which consists of the hippocampus proper or Cornu Ammonis, the dentate gyrus and the subiculum.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Human.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Human.jsonld
@@ -13,5 +13,7 @@
     "ontologyConceptID": "NCBITaxon:9606",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A mammal of the primate order and genus homo.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/HumanConnectomeProject.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/HumanConnectomeProject.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0495920",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A concerted research effort financed by the National Institutes of Health to map and create a database of neural connections of the human brain.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Longitudinal.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Longitudinal.jsonld
@@ -9,8 +9,10 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "SNOMEDCT:38717003",
+    "ontologyConceptID": "NCIT:C25242",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Running lengthwise.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/MetaAnalysis.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/MetaAnalysis.jsonld
@@ -9,8 +9,10 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "MESH:D017418",
+    "ontologyConceptID": "NCIT:C17886",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A set of statistical procedures designed to accumulate experimental and correlational results across independent studies that address a related set of research questions.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Microarray.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Microarray.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0106906",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A processed material that is made to be used in an analyte assay. It consists of a physical immobilisation matrix in which substances that bind the analyte are placed in regular spatial position.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Microscopic.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Microscopic.jsonld
@@ -9,8 +9,10 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "SNOMEDCT:84496004",
+    "ontologyConceptID": "NCIT:C25252",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Too small to be seen except under a microscope.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/MissenseMutations.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/MissenseMutations.jsonld
@@ -12,5 +12,7 @@
     "ontologyConceptID": "NCIT:C18133",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A point mutation occurring within the protein-coding region of a gene, and which codes for a different amino acid than expected.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/NeurodevelopmentalDisorder.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/NeurodevelopmentalDisorder.jsonld
@@ -10,8 +10,11 @@
         "DATS"
     ],
     "sameAs": "http://uri.interlex.org/base/ilx_0107459",
+    "ontologyConceptID": "NCIT:C89338",
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "neurodevelopmental disease"
-    }
+    },
+    "description": "A childhood disorder that has a neurological basis and manifests as a developmental disability.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Neuroimaging.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Neuroimaging.jsonld
@@ -10,8 +10,10 @@
         "DATS"
     ],
     "sameAs": "http://uri.interlex.org/base/ilx_0107478",
-    "ontologyConceptID": "MESH:D059906",
+    "ontologyConceptID": "NCIT:C173635",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The use of various techniques to directly or indirectly image the anatomy and function of the central nervous system.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Neuroscience.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Neuroscience.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0107536",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Branch of science that deals with the study of the nervous system.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/PTENGene.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/PTENGene.jsonld
@@ -10,8 +10,9 @@
         "DATS"
     ],
     "ontologyConceptID": "NCIT:C18256",
-    "description": "HGNC:9588",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "This gene plays a role in signal transduction and apoptosis. It is also involved in the regulation of cell cycle progression.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/ParkinsonSDisease.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/ParkinsonSDisease.jsonld
@@ -10,9 +10,11 @@
         "DATS"
     ],
     "sameAs": "http://uri.interlex.org/base/ilx_0764151",
-    "ontologyConceptID": "SNOMEDCT:49049000",
+    "ontologyConceptID": "NCIT:C26845",
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Parkinson disease"
-    }
+    },
+    "description": "A progressive degenerative disorder of the central nervous system characterized by loss of dopamine producing neurons in the substantia nigra and the presence of Lewy bodies in the substantia nigra and locus coeruleus. Signs and symptoms include tremor which is most pronounced during rest, muscle rigidity, slowing of the voluntary movements, a tendency to fall back, and a mask-like facial expression.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Pediatric.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Pediatric.jsonld
@@ -12,5 +12,7 @@
     "ontologyConceptID": "NCIT:C39299",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Having to do with children.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/RNA-Seq.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/RNA-Seq.jsonld
@@ -13,5 +13,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "RNAseq"
-    }
+    },
+    "description": "A topic concerning high-throughput sequencing of cDNA to measure the RNA content (transcriptome) of a sample, for example, to investigate how different alleles of a gene are expressed, detect post-transcriptional mutations or identify gene fusions.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/RawData.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/RawData.jsonld
@@ -12,5 +12,7 @@
     "ontologyConceptID": "NCIT:C142663",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The original information, collected from the primary source.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/ReferenceSequence.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/ReferenceSequence.jsonld
@@ -13,5 +13,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "RefSeq"
-    }
+    },
+    "definition": "The Reference Sequence (RefSeq) collection aims to provide a comprehensive, integrated, non-redundant set of sequences, including genomic DNA, transcript (RNA), and protein products, for major research organisms. RefSeq standards serve as the basis for medical, functional, and diversity studies; they provide a stable reference for gene identification and characterization, mutation analysis, expression studies, polymorphism discovery, and comparative analyses. RefSeqs are used as a reagent for the functional annotation of some genome sequencing projects, including those of human and mouse.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/TaskfMRI.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/TaskfMRI.jsonld
@@ -17,5 +17,7 @@
             "task functional MRI",
             "task function magnetic resonance imaging"
         ]
-    }
+    },
+    "description": "A type of functional MRI that images dynamic changes in brain tissue while the subject performs a task or experiences a sensory stimulus designed to target specific cognitive processes.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/keywords/Transcriptome.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Transcriptome.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0490137",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The pattern of GENE EXPRESSION at the level of genetic transcription in a specific organism or under specific circumstances in specific cells.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/Transcriptomics.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/Transcriptomics.jsonld
@@ -12,5 +12,7 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0739406",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The analysis of transcriptomes, or a set of all the RNA molecules in a specific cell, tissue etc.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/keywords/WhiteMatter.jsonld
+++ b/terms/CONP_DATS_Terms/keywords/WhiteMatter.jsonld
@@ -13,5 +13,7 @@
     "ontologyConceptID": "UBERON:0002316",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Parts of nervous system characterized by high concentrations of myelinated axons, giving a white glossy appearance in gross preparations.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/licenses/CC0.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CC0.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Zero License"
-    }
+    },
+    "description": "Universal tool if you are a holder of copyright or database rights, and you wish to waive all your interests in your work worldwide. Using CC0, you can waive all copyrights and related or neighboring rights that you have over your work, such as your moral rights (to the extent waivable), your publicity or privacy rights, rights you have protecting against unfair competition, and database rights and rights protecting the extraction, dissemination and reuse of data.You cannot waive rights to a work that you do not own unless you have permission from the owner. You may use this tool even if your work is free of copyright in some jurisdictions, if you want to ensure it is free everywhere. Creative Commons does not recommend this tool for works that are already in the public domain worldwide, instead use the Public Domain Mark for such works."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-4.0.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-4.0.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "CC BY Attribution 4.0 International"
-    }
+    },
+    "description": "The license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-NC-ND.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-NC-ND.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Attribution-NonCommercial-NoDerivs License"
-    }
+    },
+    "description": "License that is the most restrictive of the six Creative Commons main licenses, only allowing others to download your works and share them with others as long as they credit you in the manner specified, but they can't change them in any way or use them commercially. Notice - For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to the CC BY-NC-ND web page."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-NC-SA.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-NC-SA.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Attribution-NonCommercial-ShareAlike License"
-    }
+    },
+    "description": "License that lets others remix, tweak, and build upon your work non-commercially, as long as they credit you n the manner specified and license their new creations under the identical terms. Notice - For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to the CC BY-NC-SA web page."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-NC.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-NC.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Attribution-NonCommercial License"
-    }
+    },
+    "description": "License that lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you in the manner specified and be non-commercial, they don't have to license their derivative works on the same terms. Notice - For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to the CC BY-NC web page."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-ND.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-ND.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Attribution-NoDerivs License"
-    }
+    },
+    "description": "License that allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you in the manner specified.Notice - For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to the CC BY-ND web page."
 }

--- a/terms/CONP_DATS_Terms/licenses/CCBY-SA.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/CCBY-SA.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "Creative Commons Attribution-ShareAlike License"
-    }
+    },
+    "description": "License that lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you in the manner specified and license their new creations under the identical terms. This license is often compared to \"copyleft\" free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects. Notice - For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to the CC BY-SA web page."
 }

--- a/terms/CONP_DATS_Terms/licenses/MITLicense.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/MITLicense.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0107013",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "A free software license created by Massachusetts Institute of Technology (MIT). It is a permissive license, meaning it permits reuse within proprietary software on the condition that the MIT license is distributed with the new software.NITRC definition: The MIT license, also the X Consortium License, or a derivative, is fairly permissive, placing few restrictions on the developer or user.  As a developer, you may distribute source or binaries (with or without source code).  As a tool user, you may modify and redistribute this tool or resource.  If source code is distributed, a user may browse the source code to understand the tool's workings, modify the tool to better suit local needs, and may share a modified version.  If source code is not distributed, a user may still redistribute the tool as part of another package."
 }

--- a/terms/CONP_DATS_Terms/licenses/ODC-BY.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/ODC-BY.jsonld
@@ -16,5 +16,6 @@
             "ODC Attribution License",
             "Open Data Commons Attribution License"
         ]
-    }
+    },
+    "description": "Open license requiring attribution for data/databases."
 }

--- a/terms/CONP_DATS_Terms/licenses/ODbL.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/ODbL.jsonld
@@ -16,5 +16,6 @@
             "ODC Open Database License",
             "Open Data Commons Open Database License"
         ]
-    }
+    },
+    "description": "Open license requiring attribution and Share-Alike for Data/Databases."
 }

--- a/terms/CONP_DATS_Terms/licenses/PDDL.jsonld
+++ b/terms/CONP_DATS_Terms/licenses/PDDL.jsonld
@@ -16,5 +16,6 @@
             "ODC Public Domain Dedication and License",
             "Public Domain Dedication and License"
         ]
-    }
+    },
+    "description": "License that places the data(base) in the public domain (waiving all rights)."
 }

--- a/terms/CONP_DATS_Terms/types/EEG.jsonld
+++ b/terms/CONP_DATS_Terms/types/EEG.jsonld
@@ -13,5 +13,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "electroencephalogram"
-    }
+    },
+    "description": "The neurophysiologic exploration of the electrical activity of the brain by the application of electrodes to the scalp. The resulting traces are known as an electroencephalogram (EEG). This test is used to assess brain damage, epilepsy and other problems.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
 }

--- a/terms/CONP_DATS_Terms/types/EEG.jsonld
+++ b/terms/CONP_DATS_Terms/types/EEG.jsonld
@@ -10,10 +10,11 @@
         "DATS"
     ],
     "closeMatch": "http://purl.bioontology.org/ontology/SNOMEDCT/54550000",
+    "ontologyConceptID": "NCIT:C38054",
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "electroencephalogram"
     },
     "description": "The neurophysiologic exploration of the electrical activity of the brain by the application of electrodes to the scalp. The resulting traces are known as an electroencephalogram (EEG). This test is used to assess brain damage, epilepsy and other problems.",
-    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/types/Epigenomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Epigenomics.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "The study of the epigenetic modifications of a whole cell, tissue, organism etc."
+    "description": "The study of the epigenetic modifications of a whole cell, tissue, organism etc.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/Epigenomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Epigenomics.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0103885",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The study of the epigenetic modifications of a whole cell, tissue, organism etc."
 }

--- a/terms/CONP_DATS_Terms/types/Genetics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Genetics.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "The study of genes, genetic variation and heredity in living organisms."
+    "description": "The study of genes, genetic variation and heredity in living organisms.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/Genetics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Genetics.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0104598",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The study of genes, genetic variation and heredity in living organisms."
 }

--- a/terms/CONP_DATS_Terms/types/Genomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Genomics.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "Study that measures aspects related to the complete DNA genemone of an organsim."
+    "description": "Study that measures aspects related to the complete DNA genemone of an organsim.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/Genomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Genomics.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/ilx_0741204",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Study that measures aspects related to the complete DNA genemone of an organsim."
 }

--- a/terms/CONP_DATS_Terms/types/MRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/MRI.jsonld
@@ -15,5 +15,5 @@
         "allowableValues": "magnetic resonance imaging"
     },
     "description": "Imaging that uses radiofrequency waves and a strong magnetic field rather than x-rays to provide detailed pictures of internal organs and tissues. The technique is valuable for the diagnosis of many pathologic conditions, including cancer, heart and vascular disease, stroke, and joint and musculoskeletal disorders.",
-    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/types/MRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/MRI.jsonld
@@ -9,9 +9,11 @@
         "CONP",
         "DATS"
     ],
-    "ontologyConceptID": "SNOMED:113091000",
+    "ontologyConceptID": "NCIT:C16809",
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "magnetic resonance imaging"
-    }
+    },
+    "description": "Imaging that uses radiofrequency waves and a strong magnetic field rather than x-rays to provide detailed pictures of internal organs and tissues. The technique is valuable for the diagnosis of many pathologic conditions, including cancer, heart and vascular disease, stroke, and joint and musculoskeletal disorders.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
 }

--- a/terms/CONP_DATS_Terms/types/Medicine.jsonld
+++ b/terms/CONP_DATS_Terms/types/Medicine.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0106723",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Research in support of healing by diagnosis, treatment, and prevention of disease."
 }

--- a/terms/CONP_DATS_Terms/types/Medicine.jsonld
+++ b/terms/CONP_DATS_Terms/types/Medicine.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "Research in support of healing by diagnosis, treatment, and prevention of disease."
+    "description": "Research in support of healing by diagnosis, treatment, and prevention of disease.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/NeuropsychologicalTests.jsonld
+++ b/terms/CONP_DATS_Terms/types/NeuropsychologicalTests.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "Tests designed to assess neurological function associated with certain behaviors. They are used in diagnosing brain dysfunction or damage and central nervous system disorders or injury."
+    "description": "Tests designed to assess neurological function associated with certain behaviors. They are used in diagnosing brain dysfunction or damage and central nervous system disorders or injury.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/NeuropsychologicalTests.jsonld
+++ b/terms/CONP_DATS_Terms/types/NeuropsychologicalTests.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0485663",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Tests designed to assess neurological function associated with certain behaviors. They are used in diagnosing brain dysfunction or damage and central nervous system disorders or injury."
 }

--- a/terms/CONP_DATS_Terms/types/QualityControlSubject.jsonld
+++ b/terms/CONP_DATS_Terms/types/QualityControlSubject.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "Indicates whether or not the subject is a quality control phantom. Enumerated Values: YES NO If this Attribute is absent, then the subject may or may not be a phantom. This attribute describes a characteristic of the Imaging Subject. It is distinct from Quality Control Image (0028,0300) in the , which is used to describe an image acquired."
+    "description": "Indicates whether or not the subject is a quality control phantom. Enumerated Values: YES NO If this Attribute is absent, then the subject may or may not be a phantom. This attribute describes a characteristic of the Imaging Subject. It is distinct from Quality Control Image (0028,0300) in the , which is used to describe an image acquired.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/QualityControlSubject.jsonld
+++ b/terms/CONP_DATS_Terms/types/QualityControlSubject.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0381893",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "Indicates whether or not the subject is a quality control phantom. Enumerated Values: YES NO If this Attribute is absent, then the subject may or may not be a phantom. This attribute describes a characteristic of the Imaging Subject. It is distinct from Quality Control Image (0028,0300) in the , which is used to describe an image acquired."
 }

--- a/terms/CONP_DATS_Terms/types/TaskfMRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/TaskfMRI.jsonld
@@ -17,5 +17,7 @@
             "task functional MRI",
             "task function magnetic resonance imaging"
         ]
-    }
+    },
+    "description": "A type of functional MRI that images dynamic changes in brain tissue while the subject performs a task or experiences a sensory stimulus designed to target specific cognitive processes.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
 }

--- a/terms/CONP_DATS_Terms/types/TaskfMRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/TaskfMRI.jsonld
@@ -19,5 +19,5 @@
         ]
     },
     "description": "A type of functional MRI that images dynamic changes in brain tissue while the subject performs a task or experiences a sensory stimulus designed to target specific cognitive processes.",
-    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/types/Transcriptomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Transcriptomics.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "The analysis of transcriptomes, or a set of all the RNA molecules in a specific cell, tissue etc."
+    "description": "The analysis of transcriptomes, or a set of all the RNA molecules in a specific cell, tissue etc.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/Transcriptomics.jsonld
+++ b/terms/CONP_DATS_Terms/types/Transcriptomics.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/ilx_0739406",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The analysis of transcriptomes, or a set of all the RNA molecules in a specific cell, tissue etc."
 }

--- a/terms/CONP_DATS_Terms/types/VisualWorkingMemory.jsonld
+++ b/terms/CONP_DATS_Terms/types/VisualWorkingMemory.jsonld
@@ -13,5 +13,6 @@
     "responseOptions": {
         "valueType": "xsd:string"
     },
-    "description": "The ability to maintain visual information online for a limited time interval (~ 4 sec). This information has a capacity of ~15 items and is not stored permanently."
+    "description": "The ability to maintain visual information online for a limited time interval (~ 4 sec). This information has a capacity of ~15 items and is not stored permanently.",
+    "citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."
 }

--- a/terms/CONP_DATS_Terms/types/VisualWorkingMemory.jsonld
+++ b/terms/CONP_DATS_Terms/types/VisualWorkingMemory.jsonld
@@ -12,5 +12,6 @@
     "sameAs": "http://uri.interlex.org/base/ilx_0112531",
     "responseOptions": {
         "valueType": "xsd:string"
-    }
+    },
+    "description": "The ability to maintain visual information online for a limited time interval (~ 4 sec). This information has a capacity of ~15 items and is not stored permanently."
 }

--- a/terms/CONP_DATS_Terms/types/fMRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/fMRI.jsonld
@@ -16,5 +16,5 @@
         "allowableValues": "functional MRI"
     },
     "description": "The principle of functional MRI imaging is to take a series of images of an organ in quick succession and to statistically analyze the images for differences among them. Most commonly used in studies of brain function.",
-    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."
 }

--- a/terms/CONP_DATS_Terms/types/fMRI.jsonld
+++ b/terms/CONP_DATS_Terms/types/fMRI.jsonld
@@ -14,5 +14,7 @@
     "responseOptions": {
         "valueType": "xsd:string",
         "allowableValues": "functional MRI"
-    }
+    },
+    "description": "The principle of functional MRI imaging is to take a series of images of an organ in quick succession and to statistically analyze the images for differences among them. Most commonly used in studies of brain function.",
+    "citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27."
 }


### PR DESCRIPTION
This PR adds descriptions for some of the CONP terms.
Those terms that don't have a description yet are under consideration.
When we find/agree on descriptions for those terms I will prepare another PR.

Many descriptions added with this PR are taken from the NCIT thesaurus so in order to cite the NCIT I added a `"citation"` property to each of the terms that use the NCIT description. Other terms descriptions are taken from the SciCrunch/Interlex and contain a corresponding citation too.

Examples of citations:

`"citation": "Description reference: National Cancer Institute Thesaurus (NCIT), version 21.07d, 2021-07-27. Released under the CC BY 4.0 license."`

`"citation": "Description reference: SciCrunch/Interlex. Licensed under Attribution 3.0 Unported (CC BY 3.0)."`